### PR TITLE
[core] always generate DTMF events

### DIFF
--- a/src/switch_channel.c
+++ b/src/switch_channel.c
@@ -675,7 +675,7 @@ SWITCH_DECLARE(switch_status_t) switch_channel_dequeue_dtmf(switch_channel_t *ch
 	}
 	switch_mutex_unlock(channel->dtmf_mutex);
 
-	if (!sensitive && status == SWITCH_STATUS_SUCCESS && switch_event_create(&event, SWITCH_EVENT_DTMF) == SWITCH_STATUS_SUCCESS) {
+	if (status == SWITCH_STATUS_SUCCESS && switch_event_create(&event, SWITCH_EVENT_DTMF) == SWITCH_STATUS_SUCCESS) {
 		const char *dtmf_source_str = NULL;
 		switch_channel_event_set_data(channel, event);
 		switch_event_add_header(event, SWITCH_STACK_BOTTOM, "DTMF-Digit", "%c", dtmf->digit);


### PR DESCRIPTION
DTMF keys will be present in events anyway (e.g. play_and_get_digits), so there's no reason to supress DTMF events